### PR TITLE
Fix not URL path escaping coord ns, name, rev

### DIFF
--- a/coordinates/coordinates.go
+++ b/coordinates/coordinates.go
@@ -17,6 +17,7 @@ package coordinates
 
 import (
 	"fmt"
+	"net/url"
 	"strings"
 
 	purl "github.com/package-url/packageurl-go"
@@ -294,11 +295,16 @@ func ConvertPurlToCoordinate(purlUri string) (*Coordinate, error) {
 }
 
 func (c *Coordinate) ToString() string {
-	if c.Revision == "" {
-		return fmt.Sprintf("%s/%s/%s/%s/%22%22", c.CoordinateType, c.Provider, c.Namespace, c.Name)
-	} else {
-		return fmt.Sprintf("%s/%s/%s/%s/%s", c.CoordinateType, c.Provider, c.Namespace, c.Name, c.Revision)
+	rev := c.Revision
+	if rev == "" {
+		rev = `""`
 	}
+
+	// The namespace, name, and revision come path unescaped from net/url. We will need to
+	// re-escape them before sending them on to the ClearlyDefined API.
+
+	return fmt.Sprintf("%s/%s/%s/%s/%s", c.CoordinateType, c.Provider, url.PathEscape(c.Namespace),
+		url.PathEscape(c.Name), url.PathEscape(rev))
 }
 
 func emptyToHyphen(namespace string) string {

--- a/coordinates/coordinates_test.go
+++ b/coordinates/coordinates_test.go
@@ -277,3 +277,51 @@ func TestConvertPurlToCoordinate(t *testing.T) {
 		})
 	}
 }
+
+func TestCoordinateToString(t *testing.T) {
+	for _, tt := range []struct {
+		name       string
+		coordinate *Coordinate
+		want       string
+	}{
+		{
+			name: "django-all-auth, version 12.23",
+			coordinate: &Coordinate{
+				CoordinateType: "pypi",
+				Provider:       "pypi",
+				Namespace:      "-",
+				Name:           "django-allauth",
+				Revision:       "12.23",
+			},
+			want: "pypi/pypi/-/django-allauth/12.23",
+		},
+		{
+			name: "django-all-auth, no version",
+			coordinate: &Coordinate{
+				CoordinateType: "pypi",
+				Provider:       "pypi",
+				Namespace:      "-",
+				Name:           "django-allauth",
+				Revision:       "",
+			},
+			want: "pypi/pypi/-/django-allauth/%22%22",
+		},
+		{
+			name: "url escape namespace, name, revision",
+			coordinate: &Coordinate{
+				CoordinateType: "pypi",
+				Provider:       "pypi",
+				Namespace:      "-%",
+				Name:           "django-allauth,",
+				Revision:       "12.23?",
+			},
+			want: "pypi/pypi/-%25/django-allauth%2C/12.23%3F",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.coordinate.ToString(); got != tt.want {
+				t.Errorf("coordinate.ToString() = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- If you sent a coord to CD that required some escaping but didn't have it, then sometimes it wouldn't work properly.