### PR TITLE
Fix coordinate escaping (take two)

### DIFF
--- a/coordinates/coordinates.go
+++ b/coordinates/coordinates.go
@@ -129,6 +129,9 @@ func ConvertPurlToCoordinate(purlUri string) (*Coordinate, error) {
 	ns := emptyToHyphen(url.PathEscape(pkg.Namespace))
 	name := url.PathEscape(pkg.Name)
 	rev := url.PathEscape(pkg.Version)
+	if rev == "" {
+		rev = "%22%22"
+	}
 
 	switch pkg.Type {
 	case "cocoapods":
@@ -302,12 +305,7 @@ func ConvertPurlToCoordinate(purlUri string) (*Coordinate, error) {
 }
 
 func (c *Coordinate) ToString() string {
-	rev := c.Revision
-	if rev == "" {
-		rev = `""`
-	}
-
-	return fmt.Sprintf("%s/%s/%s/%s/%s", c.CoordinateType, c.Provider, c.Namespace, c.Name, rev)
+	return fmt.Sprintf("%s/%s/%s/%s/%s", c.CoordinateType, c.Provider, c.Namespace, c.Name, c.Revision)
 }
 
 func emptyToHyphen(namespace string) string {

--- a/coordinates/coordinates_test.go
+++ b/coordinates/coordinates_test.go
@@ -262,6 +262,17 @@ func TestConvertPurlToCoordinate(t *testing.T) {
 				Revision:       "12.23",
 			},
 			wantErr: false,
+		}, {
+			Name:    "pypi with no version",
+			purlUri: "pkg:pypi/django-allauth",
+			want: &Coordinate{
+				CoordinateType: "pypi",
+				Provider:       "pypi",
+				Namespace:      "-",
+				Name:           "django-allauth",
+				Revision:       "%22%22",
+			},
+			wantErr: false,
 		},
 	}
 	for _, tt := range tests {

--- a/coordinates/coordinates_test.go
+++ b/coordinates/coordinates_test.go
@@ -167,7 +167,7 @@ func TestConvertPurlToCoordinate(t *testing.T) {
 			want: &Coordinate{
 				CoordinateType: "go",
 				Provider:       "golang",
-				Namespace:      "cloud.google.com%2fgo",
+				Namespace:      "cloud.google.com%2Fgo",
 				Name:           "compute",
 				Revision:       "v1.23.0",
 			},
@@ -179,7 +179,7 @@ func TestConvertPurlToCoordinate(t *testing.T) {
 			want: &Coordinate{
 				CoordinateType: "go",
 				Provider:       "golang",
-				Namespace:      "github.com%2faws",
+				Namespace:      "github.com%2Faws",
 				Name:           "aws-lambda-go",
 				Revision:       "v1.46.0",
 			},
@@ -302,12 +302,12 @@ func TestCoordinateToString(t *testing.T) {
 				Provider:       "pypi",
 				Namespace:      "-",
 				Name:           "django-allauth",
-				Revision:       "",
+				Revision:       "%22%22",
 			},
 			want: "pypi/pypi/-/django-allauth/%22%22",
 		},
 		{
-			name: "url escape namespace, name, revision",
+			name: "do not url path escape namespace, name, revision (they are already escaped)",
 			coordinate: &Coordinate{
 				CoordinateType: "pypi",
 				Provider:       "pypi",
@@ -315,7 +315,18 @@ func TestCoordinateToString(t *testing.T) {
 				Name:           "django-allauth,",
 				Revision:       "12.23?",
 			},
-			want: "pypi/pypi/-%25/django-allauth%2C/12.23%3F",
+			want: "pypi/pypi/-%/django-allauth,/12.23?",
+		},
+		{
+			name: "golang github namespaces are unchanged",
+			coordinate: &Coordinate{
+				CoordinateType: "go",
+				Provider:       "golang",
+				Namespace:      "github.com%2Falecthomas",
+				Name:           "repr",
+				Revision:       "0.2.0",
+			},
+			want: "go/golang/github.com%2Falecthomas/repr/0.2.0",
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
- Previously I had changed it so that we were path escaping coord ns, name, and rev. This worked for all ecosystems except for Go where we had some bespoke escaping of slashes in namespaces. I eliminated the bespoke Go ns escaping and centralized the path escaping in the func that converts purls to coordinates, so the coordinate struct has good (escaped) values, and removed escaping the logic that I put into ToString() the last time.